### PR TITLE
Add Artifact Hub repository metadata file to claim repository ownership

### DIFF
--- a/docs/artifacthub-repo.yml
+++ b/docs/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+# Artifact Hub repository metadata file
+owners: # (optional, used to claim repository ownership)
+  - name: stakater-user
+    email: stakater@gmail.com


### PR DESCRIPTION
The `stakater` repository is currently published by MaxRink on ArtifactHub - add a metadata file to the repo as the first step in claiming ownership of the repo.

The `artifacthub-repo.yml` metadata file must be located at the repository URL’s path. In Helm repositories this means it must be located at the same level of the chart repository `index.yaml` file, and it must be served from the chart repository HTTP server as well