### PR TITLE
Add repository ID in Artifact Hub metadata file

### DIFF
--- a/docs/artifacthub-repo.yml
+++ b/docs/artifacthub-repo.yml
@@ -1,4 +1,5 @@
 # Artifact Hub repository metadata file
+repositoryID: 8c862b6e-5ea5-4dfd-b903-78fcc8315155
 owners: # (optional, used to claim repository ownership)
   - name: stakater-user
     email: stakater@gmail.com


### PR DESCRIPTION
Now when the repository has been claimed, we know the id, and can add it to the metadata file so the repository becomes labeled as `Verified Publisher`